### PR TITLE
fix(output): using new GitHub Actions outputs method + add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,56 @@
+name: CI
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+env:
+  NODE_VERSION: 20
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Fail test
+        continue-on-error: true
+        uses: ./
+        with:
+          path: tests
+
+      - run: npm version patch --force
+        working-directory: ./tests
+
+      - name: Success test
+        id: test
+        uses: ./
+        with:
+          path: tests
+
+      - run: |
+          echo "name: ${{ steps.test.outputs.name }}"
+          echo "version: ${{ steps.test.outputs.version }}"
+          echo "release: ${{ steps.test.outputs.release }}"
+
+          if [[ "${{ steps.test.outputs.name }}" != "check-version-test" ]]; then
+            echo "The name output is not correct"
+            exit 1
+          fi
+
+          if [[ "${{ steps.test.outputs.version }}" != "0.0.1" ]]; then
+            echo "The version output is not correct"
+            exit 1
+          fi
+
+          if [[ "${{ steps.test.outputs.release }}" != "check-version-test_v0.0.1+build.2.zip" ]]; then
+            echo "The release output is not correct"
+            exit 1
+          fi

--- a/main.js
+++ b/main.js
@@ -5,6 +5,8 @@
 
 const path = require("path");
 const cp = require("child_process");
+const fs = require("fs")
+const os = require("os")
 
 // If the semver string a is greater than b, return 1. If the semver string b is greater than a, return -1. If a equals b, return 0;
 var semver =
@@ -136,6 +138,7 @@ const release = INPUT_FORMAT.replace(/\{pkg\}/gi, head.name)
   .replace(/\{pr_number\}/gi, event.pull_request.number);
 
 // Set the action output values (name, version, release)
-console.log(`::set-output name=name::${head.name}`);
-console.log(`::set-output name=version::${head.version}`);
-console.log(`::set-output name=release::${release}`);
+const output = process.env['GITHUB_OUTPUT']
+fs.appendFileSync(output, `name=${head.name}${os.EOL}`)
+fs.appendFileSync(output, `version=${head.version}${os.EOL}`)
+fs.appendFileSync(output, `release=${release}${os.EOL}`)

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "check-version-test",
+  "version": "0.0.0",
+  "description": "Project to test this GitHub Action",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC"
+}


### PR DESCRIPTION
Fixes https://github.com/kriasoft/check-version/issues/9

GitHub post and docs:
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions\#setting-an-output-parameter